### PR TITLE
debian/rules: fix package build on wheezy

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,7 @@
 
 NAME=hp-n54l
 DEB_NAME=$(NAME)-dkms
-VERSION=$(shell dpkg-parsechangelog --show-field Version | sed 's/~.*$$//')
+VERSION=$(shell dpkg-parsechangelog | awk '$$1 == "Version:" {print $$2}')
 
 %:
 	dh $@ --with dkms


### PR DESCRIPTION
Hi,

I have serveral old machines still running oldstable.
This fixes compilation on wheezy and works on newer Debian versions.
