### PR TITLE
debian/rules: fix package build on wheezy

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,7 @@
 
 NAME=hp-n54l
 DEB_NAME=$(NAME)-dkms
-VERSION=$(shell dpkg-parsechangelog --show-field Version | sed 's/~.*$$//')
+VERSION=$(shell dpkg-parsechangelog | sed -nre 's/^Version: ([^-~]+).*$$/\1/p' )
 
 %:
 	dh $@ --with dkms


### PR DESCRIPTION
This allows building the Debian package on wheezy (old stable) systems.
