### PR TITLE
use KVER supplied via dkms.conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 obj-m += i2c-piix4.o
 
 all:
-		make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+		make -C /lib/modules/$(KVER)/build M=$(PWD) modules
 
 clean:
-		make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+		make -C /lib/modules/$(KVER)/build M=$(PWD) clean


### PR DESCRIPTION
this allows building for all installed kernels.
the old method via `uname -r` allowed only building
for the running kernel.
DKMS build for other kernels failed, or a module was build with wrong
version symbols, but the module was installed for the wrong kernel.